### PR TITLE
Validate API Key Function Fix

### DIFF
--- a/src/Lms/Canvas/CanvasLms.php
+++ b/src/Lms/Canvas/CanvasLms.php
@@ -122,16 +122,46 @@ class CanvasLms implements LmsInterface {
 
     public function testApiConnection(User $user)
     {
-        $url = 'users/self';
-        $apiDomain = $this->getApiDomain($user);
-        $apiToken = $this->getApiToken($user);
+        $api_status = [];
+        $apiKey = $user->getApiKey();
 
-        $canvasApi = new CanvasApi($apiDomain, $apiToken);
-        $response = $canvasApi->apiGet($url);
+        $output = new ConsoleOutput();
+        // Check if the API key exists
+        if(empty($apiKey)){
+            $api_status['sucess'] = false;
+            $api_status['message'] = "User does not have an API Key. Please refresh the page to try again or contact your adminstrator";
+            return $api_status;
+        }
+        else{
+            $url = 'users/self';
+            $apiDomain = $this->getApiDomain($user);
+            $apiToken = $this->getApiToken($user);
 
-        return ($response->getStatusCode() < 400);
+            $canvasApi = new CanvasApi($apiDomain, $apiToken);
+            $response = $canvasApi->apiGet($url);
+
+            $statusCode = $response->getStatusCode();
+            if($statusCode == 500){
+                $api_status['sucess'] = false;
+                $api_status['message'] = "Something went wrong. Please refresh the page to try again or contact your adminstrator";
+            }
+            else if($statusCode == 404) {
+                $api_status['sucess'] = false;
+                $api_status['message'] = "User does not have an API Key. Please refresh the page to try again or contact your adminstrator";
+            }
+            else if($statusCode == 401){
+                $api_status['sucess'] = false;
+                $api_status['message'] = "Failed to authenticate user";
+            }
+            else{
+                $api_status['sucess'] = true;
+                $api_status['message'] = "Successfully verified user.";
+            }
+            
+        }
+
+        return $api_status;
     }
-
     /**
      * ****************
      * Course Functions

--- a/src/Lms/Canvas/CanvasLms.php
+++ b/src/Lms/Canvas/CanvasLms.php
@@ -128,7 +128,7 @@ class CanvasLms implements LmsInterface {
         $output = new ConsoleOutput();
         // Check if the API key exists
         if(empty($apiKey)){
-            $api_status['sucess'] = false;
+            $api_status['success'] = false;
             $api_status['message'] = "User does not have an API Key. Please refresh the page to try again or contact your adminstrator";
             return $api_status;
         }
@@ -142,19 +142,19 @@ class CanvasLms implements LmsInterface {
 
             $statusCode = $response->getStatusCode();
             if($statusCode == 500){
-                $api_status['sucess'] = false;
+                $api_status['success'] = false;
                 $api_status['message'] = "Something went wrong. Please refresh the page to try again or contact your adminstrator";
             }
             else if($statusCode == 404) {
-                $api_status['sucess'] = false;
+                $api_status['success'] = false;
                 $api_status['message'] = "User does not have an API Key. Please refresh the page to try again or contact your adminstrator";
             }
             else if($statusCode == 401){
-                $api_status['sucess'] = false;
+                $api_status['success'] = false;
                 $api_status['message'] = "Failed to authenticate user";
             }
             else{
-                $api_status['sucess'] = true;
+                $api_status['success'] = true;
                 $api_status['message'] = "Successfully verified user.";
             }
             

--- a/src/Services/LmsUserService.php
+++ b/src/Services/LmsUserService.php
@@ -41,17 +41,17 @@ class LmsUserService {
 
         try {
             $api_status = $lms->testApiConnection($user);
-            if(!$api_status['sucess']){
+            if(!$api_status['success']){
                 for($i = 0; $i < $max_retries; $i++){
                     if($this->refreshApiKey($user)){
                         $api_status = $lms->testApiConnection($user);
-                        if ($api_status['sucess']){
+                        if ($api_status['success']){
                             break;
                         }
                     }
                 }
             }
-            if(!$api_status['sucess']){
+            if(!$api_status['success']){
                 $this->util->exitWithMessage($api_status['message']);
             }
         }

--- a/src/Services/LmsUserService.php
+++ b/src/Services/LmsUserService.php
@@ -7,6 +7,8 @@ use App\Services\LmsApiService;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpClient\Exception\TimeoutException;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
 
 class LmsUserService {
 
@@ -32,30 +34,32 @@ class LmsUserService {
     }
 
     // Returns true if API key has been validated.
-    public function validateApiKey(User $user): bool
+    public function validateApiKey(User $user)
     {
-        $apiKey = $user->getApiKey();
         $lms = $this->lmsApi->getLms();
-
-        if (empty($apiKey)) {
-            return false;
-        }
+        $max_retries = 1;
 
         try {
-            return $lms->testApiConnection($user);
-        }
-        catch (\Exception $e) {
-            if(!$this->refreshApiKey($user)) {
-                return false;
+            $api_status = $lms->testApiConnection($user);
+            if(!$api_status['sucess']){
+                for($i = 0; $i < $max_retries; $i++){
+                    if($this->refreshApiKey($user)){
+                        $api_status = $lms->testApiConnection($user);
+                        if ($api_status['sucess']){
+                            break;
+                        }
+                    }
+                }
             }
-        }
-
-        try {
-            return $lms->testApiConnection($user);
+            if(!$api_status['sucess']){
+                $this->util->exitWithMessage($api_status['message']);
+            }
         }
         catch (\Exception $e) {
             $this->util->exitWithMessage($e->getMessage());
         }
+
+        return true;
     }
 
     public function refreshApiKey(User $user)


### PR DESCRIPTION
Fix for proper exception handling for validating API keys. Adds custom error messages with proper errors. When validating the key it can either return `true` or exit the program with a proper exception message.

### Testing

Need some way to have invalid API keys while having the correct auth token for testing. 